### PR TITLE
Recognise glyph abbreviations (not just indexes)

### DIFF
--- a/pSBOLv-cli/pSBOLv-cli.py
+++ b/pSBOLv-cli/pSBOLv-cli.py
@@ -104,12 +104,35 @@ def find_glyph(value, renderer):
         orientation = 'reverse'
         value = value.replace('<', '')
     library = renderer.glyphs_library
-    glyphs = list(library.keys())
-    index = int(value)
-    glyph = glyphs[index]
+
+    abbreviations = {
+        '?': 'Unspecified',
+        '3': "3' Sticky Restriction Site",
+        '5': "5' Sticky Restriction Site",
+        'p': 'Promoter',
+        'r': 'RibosomeEntrySite',
+        'c': 'CDS',
+        'g': 'CDS', # TODO: for pigeon compatability, this should be the variant arrow (rather than pentagon) glyph
+        # f is recognised by pigeon, but not this tool
+        't': 'Terminator',
+        's': 'Spacer',
+        'o': 'Operator',
+        '>': 'Recombination Site',
+        '<': 'Recombination Site' # TODO: should be in reverse orientation
+
+        # I don't know what |/x/x/d are meant to represent in Pigeon
+    }
+
+    if value in abbreviations:
+        glyph = abbreviations[value]
+    else:
+        glyphs = list(library.keys())
+        index = int(value)
+        glyph = glyphs[index]
+
     return glyph, orientation
 
-
+  
 def find_color(value):
     """Finds glyph name from index.
 

--- a/pSBOLv-cli/pSBOLv-cli.py
+++ b/pSBOLv-cli/pSBOLv-cli.py
@@ -107,8 +107,8 @@ def find_glyph(value, renderer):
 
     abbreviations = {
         '?': 'Unspecified',
-        '3': "3' Sticky Restriction Site",
-        '5': "5' Sticky Restriction Site",
+        '3': "3' Overhang Site",
+        '5': "5' Overhang Site",
         'p': 'Promoter',
         'r': 'RibosomeEntrySite',
         'c': 'CDS',


### PR DESCRIPTION
One problem with this is that pigeon used `3`/`5` to represent 3' and 5' sticky overhangs - this would be ambiguous with index 3/5. An alternative would be to use `3'`/`5'` instead.